### PR TITLE
Support MLP Message Terminator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,11 @@ var Transform = require('stream').Transform
   , Message = require('./message')
   , utils = require('./utils')
 
+// MLP start and end frames
+var VT = String.fromCharCode(0x0b)
+  , FS = String.fromCharCode(0x1c)
+  , CR = String.fromCharCode(0x0d)
+
 exports.Message = Message
 exports.Segment = Segment
 exports.Parser = Parser
@@ -63,6 +68,7 @@ Parser.prototype._transform = function(data, encoding, done) {
     segment = null
     return
   }
+  
   if (segment && segment.parsed) {
     var isHeader = utils.segmentIsHeader(segment)
     if (isHeader && this.current) {
@@ -76,6 +82,15 @@ Parser.prototype._transform = function(data, encoding, done) {
       this.current.addSegment(segment)
     } else {
       this.current.addSegment(segment)
+    }
+    
+    /* 
+      If the message ended with FS+CR, this indicates the end of the message 
+      and it should be pushed over the transform stream now
+    */
+    if (data.indexOf(FS + CR) !== -1) {
+      this.emit('message', this.current)
+      this.current = null
     }
   }
   done()

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,8 @@ var Transform = require('stream').Transform
   , Message = require('./message')
   , utils = require('./utils')
 
-// MLP start and end frames
-var VT = String.fromCharCode(0x0b)
-  , FS = String.fromCharCode(0x1c)
+// MLP end frames
+var FS = String.fromCharCode(0x1c)
   , CR = String.fromCharCode(0x0d)
 
 exports.Message = Message
@@ -86,7 +85,8 @@ Parser.prototype._transform = function(data, encoding, done) {
     
     /* 
       If the message ended with FS+CR, this indicates the end of the message 
-      and it should be pushed over the transform stream now
+      and it should be pushed over the transform stream now.
+      http://www.hl7standards.com/blog/2007/05/02/hl7-mlp-minimum-layer-protocol-defined/
     */
     if (data.indexOf(FS + CR) !== -1) {
       this.emit('message', this.current)

--- a/test/streams.js
+++ b/test/streams.js
@@ -1,0 +1,65 @@
+var should = require('should')
+  , Parser = require('../').Parser
+  , split = require('split')
+  , path = require('path')
+  , fs = require('fs')
+  , parser
+
+describe('Streams', function() {
+  beforeEach(function() {
+    parser = new Parser()
+  })
+  
+  it('should emit message once if one message is written to the parser', function(done) {    
+    parser.on('message', function(message) {
+      should.ok(message.segmentTypes.indexOf('MSH') !== -1, 'should contain the MSH segment')
+      should.ok(message.segmentTypes.indexOf('PID') !== -1, 'should contain the MSH segment')
+      should.ok(message.segmentTypes.indexOf('NK1') !== -1, 'should contain the MSH segment')
+      should.ok(message.segmentTypes.indexOf('PV1') !== -1, 'should contain the MSH segment')
+      
+      done()
+    })
+    
+    var test = path.join(__dirname, 'fixtures', 'test.hl7')    
+    var contents = fs.readFileSync(test, 'utf8').split('\r')
+    
+    contents.forEach(function(piece) {
+      parser.write(piece);
+    });
+  })
+  
+  it('should emit message twice if two messages are written to the parser', function(done) {    
+    parser.on('message', function(message) {
+      this.segmentCounts = (this.segmentCounts) ? this.segmentCounts :  {}
+      this.messageCount = (this.messageCount) ? this.messageCount + 1 : 1
+            
+      message.segmentTypes.forEach(function(type) {
+        this.segmentCounts[type] = (this.segmentCounts.hasOwnProperty(type) === false) ? 1 : this.segmentCounts[type] + 1
+      }.bind(this))
+      
+      if (this.messageCount === 2) {
+        should.equal(this.messageCount, 2)
+        should.equal(this.segmentCounts.MSH, 2)
+        should.equal(this.segmentCounts.PID, 2)
+        should.equal(this.segmentCounts.NK1, 2)
+        should.equal(this.segmentCounts.PV1, 2)
+        
+        done()
+      }
+    })
+    
+    var test = path.join(__dirname, 'fixtures', 'test.hl7')
+    var test2 = path.join(__dirname, 'fixtures', 'test2.hl7')
+    
+    var contents = fs.readFileSync(test, 'utf8').split('\r')
+    var contents2 = fs.readFileSync(test2, 'utf8').split('\r')
+    
+    contents.forEach(function(piece) {
+      parser.write(piece);
+    });
+    
+    contents2.forEach(function(piece) {
+      parser.write(piece);
+    });
+  })
+})


### PR DESCRIPTION
I had a problem using this because the behavior of the transform stream basically would leave the last message sitting in the internal queue (`this.current`) without any way of flushing it.  The HL7 MLP specifies a message footer of `file separator` + `carriage return` characters, so I thought that'd be as good a way as any of specifying the end of a given message.  Happy to hear your thoughts around this!