### PR TITLE
[FIXED] Parser incorrectly grabbing whitespace chars in the beginning…

### DIFF
--- a/lib/segment.js
+++ b/lib/segment.js
@@ -80,6 +80,8 @@ Segment.prototype.parse = function(data) {
   if (data && data.length > 1) { // account for trailing \r
     data = data.replace(/\u000b/g, '')
                .replace(/\u001c/g, '')
+               .trim()
+               
     this._raw = data
     var s = data.slice(0, 3)
     if (s === 'MSH' || s === 'BHS' || s === 'FHS') {


### PR DESCRIPTION
… of messages

These are ending from the previous lines \r\n